### PR TITLE
Feat/Infinite-scroll-pagination

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.4.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
@@ -29,8 +30,27 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.apache.commons:commons-lang3:3.0'
+    implementation 'com.querydsl:querydsl-jpa:4.2.1'
+    implementation 'com.querydsl:querydsl-sql-spring:4.2.1'
+    implementation 'joda-time:joda-time:2.9.4'
 }
 
 test {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/openhack/toyland/controller/ToyController.java
+++ b/src/main/java/com/openhack/toyland/controller/ToyController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -40,9 +41,20 @@ public class ToyController {
 
 	@GetMapping
 	public ResponseEntity<List<ToyResponse>> findAll(
-		@PageableDefault(size = 6, sort = "updated_date", direction = Sort.Direction.DESC) Pageable pageable) {
-		log.info(pageable.getOffset() + " " + pageable.toString());
-		List<ToyResponse> responses = service.findAll(pageable);
+		@PageableDefault(size = 6, sort = "created_date", direction = Sort.Direction.DESC) Pageable pageable,
+		@RequestParam(required = false) List<Long> organization,
+		@RequestParam(required = false) List<Long> skill,
+		@RequestParam(required = false) List<String> category,
+		@RequestParam(required = false) List<String> period,
+		@RequestParam(required = false) List<String> search
+	) {
+		log.info("[get toy condition] - " + pageable.toString());
+		log.info("[get toy condition] - " + organization);
+		log.info("[get toy condition] - " + skill);
+		log.info("[get toy condition] - " + category);
+		log.info("[get toy condition] - " + period);
+		log.info("[get toy condition] - " + search);
+		List<ToyResponse> responses = service.findAll(pageable, organization, skill, category, period, search);
 		log.info(responses.toString());
 		return ResponseEntity.ok(responses);
 	}

--- a/src/main/java/com/openhack/toyland/controller/ToyController.java
+++ b/src/main/java/com/openhack/toyland/controller/ToyController.java
@@ -1,20 +1,8 @@
 package com.openhack.toyland.controller;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
-
-import javax.validation.Valid;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.openhack.toyland.dto.ToyCreateRequest;
 import com.openhack.toyland.dto.ToyDetailResponse;
 import com.openhack.toyland.dto.ToyResponse;
@@ -22,6 +10,17 @@ import com.openhack.toyland.service.toy.ToyCreateService;
 import com.openhack.toyland.service.toy.ToyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @CrossOrigin("*")
@@ -29,27 +28,29 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/toys")
 @RestController
 public class ToyController {
-    private final ToyService service;
-    private final ToyCreateService createService;
+	private final ToyService service;
+	private final ToyCreateService createService;
 
-    @PostMapping
-    public ResponseEntity<Void> create(@RequestBody @Valid ToyCreateRequest request) {
-        Long id = createService.create(request);
-        log.info(Long.toString(id));
-        return ResponseEntity.created(URI.create("/api/toys/" + id)).build();
-    }
+	@PostMapping
+	public ResponseEntity<Void> create(@RequestBody @Valid ToyCreateRequest request) {
+		Long id = createService.create(request);
+		log.info(Long.toString(id));
+		return ResponseEntity.created(URI.create("/api/toys/" + id)).build();
+	}
 
-    @GetMapping
-    public ResponseEntity<List<ToyResponse>> findAll() {
-        List<ToyResponse> responses = service.findAll();
-        log.info(responses.toString());
-        return ResponseEntity.ok(responses);
-    }
+	@GetMapping
+	public ResponseEntity<List<ToyResponse>> findAll(
+		@PageableDefault(size = 6, sort = "updated_date", direction = Sort.Direction.DESC) Pageable pageable) {
+		log.info(pageable.getOffset() + " " + pageable.toString());
+		List<ToyResponse> responses = service.findAll(pageable);
+		log.info(responses.toString());
+		return ResponseEntity.ok(responses);
+	}
 
-    @GetMapping("/{id}")
-    public ResponseEntity<ToyDetailResponse> findById(@PathVariable Long id) {
-        ToyDetailResponse response = service.findById(id);
-        log.info(response.toString());
-        return ResponseEntity.ok(response);
-    }
+	@GetMapping("/{id}")
+	public ResponseEntity<ToyDetailResponse> findById(@PathVariable Long id) {
+		ToyDetailResponse response = service.findById(id);
+		log.info(response.toString());
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/openhack/toyland/domain/toy/ToyRepository.java
+++ b/src/main/java/com/openhack/toyland/domain/toy/ToyRepository.java
@@ -1,6 +1,15 @@
 package com.openhack.toyland.domain.toy;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ToyRepository extends JpaRepository<Toy, Long> {
+
+	@Query(
+		value = "SELECT * FROM toy ORDER BY id",
+		countQuery = "SELECT count(*) FROM toy",
+		nativeQuery = true)
+	Page<Toy> findAllToysWithPagination(Pageable pageable);
 }

--- a/src/main/java/com/openhack/toyland/domain/toy/ToyRepository.java
+++ b/src/main/java/com/openhack/toyland/domain/toy/ToyRepository.java
@@ -1,15 +1,6 @@
 package com.openhack.toyland.domain.toy;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface ToyRepository extends JpaRepository<Toy, Long> {
-
-	@Query(
-		value = "SELECT * FROM toy ORDER BY id",
-		countQuery = "SELECT count(*) FROM toy",
-		nativeQuery = true)
-	Page<Toy> findAllToysWithPagination(Pageable pageable);
 }

--- a/src/main/java/com/openhack/toyland/domain/toy/ToySearchAndSortRepository.java
+++ b/src/main/java/com/openhack/toyland/domain/toy/ToySearchAndSortRepository.java
@@ -1,0 +1,123 @@
+package com.openhack.toyland.domain.toy;
+
+import static com.openhack.toyland.domain.QMaintenance.*;
+import static com.openhack.toyland.domain.QOrganization.*;
+import static com.openhack.toyland.domain.skill.QTechStack.*;
+import static com.openhack.toyland.domain.toy.QToy.*;
+import javax.persistence.EntityManager;
+import java.util.List;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ToySearchAndSortRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public ToySearchAndSortRepository(EntityManager entityManager) {
+		this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	public List<Toy> findToysByConditions(Pageable pageable, List<Long> organizations, List<Long> skills,
+		List<String> categories, List<String> periods, List<String> searches) {
+		return jpaQueryFactory.select(toy)
+			.from(toy)
+			.leftJoin(maintenance).on(toy.id.eq(maintenance.toyId))
+			.leftJoin(organization).on(toy.organizationId.eq(organization.id))
+			.leftJoin(techStack).on(techStack.toyId.eq(toy.id))
+			.where(
+				isOrganizationFilter(organizations),
+				isSkillFilter(skills),
+				isCategoryFilter(categories),
+				isPeriodFilter(periods)
+				// isSearchFilter(searches)
+			)
+			.orderBy(orderType(pageable.getSort()))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+	}
+
+	private OrderSpecifier<?> orderType(Sort sort) {
+		if (StringUtils.equals(sort.toString(), "active")) {
+			return maintenance.active.desc();
+		}
+
+		return toy.createdDate.desc();
+	}
+
+	private BooleanExpression isOrganizationFilter(List<Long> organizationId) {
+		if (organizationId == null) {
+			return null;
+		}
+
+		return Expressions.anyOf(organizationId.stream().map(this::isOrganization).toArray(BooleanExpression[]::new));
+	}
+
+	private BooleanExpression isOrganization(Long organizationId) {
+		if (organizationId != null) {
+			return null;
+		}
+		return organization.id.eq(organizationId);
+	}
+
+	private BooleanExpression isSkillFilter(List<Long> skillId) {
+		if (skillId == null) {
+			return null;
+		}
+
+		return Expressions.anyOf(skillId.stream().map(this::isSkill).toArray(BooleanExpression[]::new));
+	}
+
+	private BooleanExpression isSkill(Long skillId) {
+		if (skillId != null) {
+			return null;
+		}
+		return techStack.skillId.eq(skillId);
+	}
+
+	private BooleanExpression isCategoryFilter(List<String> category) {
+		if (category == null) {
+			return null;
+		}
+
+		return Expressions.anyOf(category.stream().map(this::isCategory).toArray(BooleanExpression[]::new));
+	}
+
+	private BooleanExpression isCategory(String category) {
+		if (StringUtils.isEmpty(category)) {
+			return null;
+		}
+		return toy.category.eq(Category.valueOf(category));
+	}
+
+	private BooleanExpression isPeriodFilter(List<String> period) {
+		if (period == null) {
+			return null;
+		}
+
+		return Expressions.anyOf(period.stream().map(this::isPeriod).toArray(BooleanExpression[]::new));
+
+	}
+
+	private BooleanExpression isPeriod(String period) {
+		if (StringUtils.isEmpty(period)) {
+			return null;
+		}
+		return toy.period.eq(Period.valueOf(period));
+	}
+
+	// TODO: 명확한 검색 범위
+	// private BooleanExpression isSearchFilter(List<String> search) {
+	// }
+	//
+	// private BooleanExpression isSearch(String search) {
+	//
+	// }
+}

--- a/src/main/java/com/openhack/toyland/service/toy/ToyService.java
+++ b/src/main/java/com/openhack/toyland/service/toy/ToyService.java
@@ -1,31 +1,29 @@
 package com.openhack.toyland.service.toy;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-
 import com.openhack.toyland.domain.toy.Toy;
 import com.openhack.toyland.domain.toy.ToyRepository;
 import com.openhack.toyland.dto.ToyDetailResponse;
 import com.openhack.toyland.dto.ToyResponse;
 import com.openhack.toyland.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class ToyService {
-    private final ToyRepository repository;
+	private final ToyRepository repository;
 
-    public List<ToyResponse> findAll() {
-        return repository.findAll().stream()
-            .map(ToyResponse::new)
-            .collect(Collectors.toList());
-    }
+	public List<ToyResponse> findAll(Pageable pageable) {
+		return repository.findAllToysWithPagination(pageable)
+			.map(ToyResponse::new)
+			.toList();
+	}
 
-    public ToyDetailResponse findById(Long id) {
-        Toy toy = repository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException("해당되는 toy가 없습니다."));
-        return new ToyDetailResponse(toy);
-    }
+	public ToyDetailResponse findById(Long id) {
+		Toy toy = repository.findById(id)
+			.orElseThrow(() -> new EntityNotFoundException("해당되는 toy가 없습니다."));
+		return new ToyDetailResponse(toy);
+	}
 }

--- a/src/main/java/com/openhack/toyland/service/toy/ToyService.java
+++ b/src/main/java/com/openhack/toyland/service/toy/ToyService.java
@@ -1,8 +1,10 @@
 package com.openhack.toyland.service.toy;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import com.openhack.toyland.domain.toy.Toy;
 import com.openhack.toyland.domain.toy.ToyRepository;
+import com.openhack.toyland.domain.toy.ToySearchAndSortRepository;
 import com.openhack.toyland.dto.ToyDetailResponse;
 import com.openhack.toyland.dto.ToyResponse;
 import com.openhack.toyland.exception.EntityNotFoundException;
@@ -13,16 +15,19 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class ToyService {
-	private final ToyRepository repository;
+	private final ToyRepository toyRepository;
+	private final ToySearchAndSortRepository toySearchAndSortRepository;
 
-	public List<ToyResponse> findAll(Pageable pageable) {
-		return repository.findAllToysWithPagination(pageable)
+	public List<ToyResponse> findAll(Pageable pageable, List<Long> organization, List<Long> skill,
+		List<String> category, List<String> period, List<String> search) {
+		return toySearchAndSortRepository.findToysByConditions(pageable, organization, skill, category, period, search)
+			.stream()
 			.map(ToyResponse::new)
-			.toList();
+			.collect(Collectors.toList());
 	}
 
 	public ToyDetailResponse findById(Long id) {
-		Toy toy = repository.findById(id)
+		Toy toy = toyRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException("해당되는 toy가 없습니다."));
 		return new ToyDetailResponse(toy);
 	}


### PR DESCRIPTION
resolves #9 #10 #13

**!! toy get api의 경우 정렬, 검색, 필터링 모두 복합적으로 적용되길 바라셔서
저희가 이야기 했었던 api를 나누기보다는 query param으로 전달된 것에 맞게 정렬+검색+필터링 하기로 변경했습니다.**

스타일 적용이 잘 안되는지 인덴테이션이 계속 바뀌네요ㅠ.ㅠ

## 변경 사항
toy 여러건 조회 시 페이지네이션 적용
정렬 + 필터링까지 일단 구현
(추후에 무한스크롤 구현)