### PR TITLE
fix: update sleep days when toy service link is not empty string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,14 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-core'
     implementation 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.apache.commons:commons-lang3:3.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.apache.commons:commons-lang3:3.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/src/main/java/com/openhack/toyland/ToyLandApplication.java
+++ b/src/main/java/com/openhack/toyland/ToyLandApplication.java
@@ -2,10 +2,8 @@ package com.openhack.toyland;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class ToyLandApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/openhack/toyland/config/ScheduledConfig.java
+++ b/src/main/java/com/openhack/toyland/config/ScheduledConfig.java
@@ -1,0 +1,13 @@
+package com.openhack.toyland.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@ConditionalOnProperty(
+    value = "app.scheduling.enable", havingValue = "true", matchIfMissing = true
+)
+@Configuration
+@EnableScheduling
+public class ScheduledConfig {
+}

--- a/src/main/java/com/openhack/toyland/domain/Maintenance.java
+++ b/src/main/java/com/openhack/toyland/domain/Maintenance.java
@@ -12,10 +12,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@ToString
 public class Maintenance extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/openhack/toyland/domain/MaintenanceRepository.java
+++ b/src/main/java/com/openhack/toyland/domain/MaintenanceRepository.java
@@ -3,6 +3,7 @@ package com.openhack.toyland.domain;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MaintenanceRepository extends JpaRepository<Maintenance, Long> {
     boolean existsByToyId(Long toyId);
@@ -12,4 +13,7 @@ public interface MaintenanceRepository extends JpaRepository<Maintenance, Long> 
     void deleteByToyId(Long deleteByToyId);
 
     List<Maintenance> findBySleepDaysGreaterThan(Long threshold);
+
+    @Query("select m as maintenance, t.githubLink as githubLink, t.serviceLink as serviceLink from Maintenance m inner join Toy t on t.id=m.toyId where t.serviceLink is not null and t.serviceLink <> ''")
+    List<UpdatableMaintenance> findAllByNeedsHealthCheck();
 }

--- a/src/main/java/com/openhack/toyland/domain/UpdatableMaintenance.java
+++ b/src/main/java/com/openhack/toyland/domain/UpdatableMaintenance.java
@@ -1,0 +1,7 @@
+package com.openhack.toyland.domain;
+
+public interface UpdatableMaintenance {
+    Maintenance getMaintenance();
+    String getGithubLink();
+    String getServiceLink();
+}

--- a/src/main/java/com/openhack/toyland/infra/ApiParser.java
+++ b/src/main/java/com/openhack/toyland/infra/ApiParser.java
@@ -29,6 +29,7 @@ public class ApiParser {
     private String apiToken;
 
     public boolean checkHealth(String link) {
+        log.info("[health-check]:" + link);
         ResponseEntity<String> response = null;
         try {
             response = restTemplate.getForEntity(link, String.class);

--- a/src/main/java/com/openhack/toyland/service/maintenance/MaintenanceService.java
+++ b/src/main/java/com/openhack/toyland/service/maintenance/MaintenanceService.java
@@ -3,6 +3,7 @@ package com.openhack.toyland.service.maintenance;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.openhack.toyland.domain.UpdatableMaintenance;
 import org.springframework.stereotype.Service;
 
 import com.openhack.toyland.domain.Maintenance;
@@ -19,6 +20,10 @@ public class MaintenanceService {
 
     public List<Maintenance> findAll() {
         return repository.findAll();
+    }
+
+    public List<UpdatableMaintenance> findAllNeedsHealthCheck() {
+        return repository.findAllByNeedsHealthCheck();
     }
 
     public void associate(LocalDateTime pushedAt, String serviceLink, Long toyId) {

--- a/src/test/java/com/openhack/toyland/service/maintenance/ScheduleServiceTest.java
+++ b/src/test/java/com/openhack/toyland/service/maintenance/ScheduleServiceTest.java
@@ -1,0 +1,35 @@
+package com.openhack.toyland.service.maintenance;
+
+import java.util.List;
+import com.openhack.toyland.domain.UpdatableMaintenance;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "app.scheduling.enable=false")
+@SpringBootTest
+public class ScheduleServiceTest {
+
+    @Autowired
+    ScheduleService scheduleService;
+
+    @Autowired
+    MaintenanceService maintenanceService;
+
+    @Test
+    @DisplayName("toy.service_link 가 빈 문자열이 아닌 maintenance 를 가져오는 테스트")
+    public void testNotToFindToyServiceLinkIsEmpty(){
+        List<UpdatableMaintenance> updatableMaintenanceList = maintenanceService.findAllNeedsHealthCheck();
+        for(UpdatableMaintenance updatableMaintenance: updatableMaintenanceList){
+            Assertions.assertNotNull(updatableMaintenance.getServiceLink());
+        }
+    }
+
+    @Test
+    public void testUpdateHealthCheck() {
+        scheduleService.updateMaintenance();
+    }
+}


### PR DESCRIPTION
resolves #40 

## 변경 사항
- 테스트 시 scheduling disable을 위해 `@EnableScheduling` -> ScheduledConfig.java 분리

- UpdatableMaintenance: jpql projection을 위한 interface
- MaintenanceRepository
    - findAllByNeedsHealthCheck() 추가: maintenance와 toy를 inner join 후 toy.service_link가 빈 문자열이 아닌 결과물만 리턴

- - - 
email 링크가 있는 toy를 대상으로만 `sleepDays` update를 진행해도 되지 않을까 하는 생각도 드네요