### PR TITLE
Maintenenance의  created_date가 안들어가는 이유를 파악한다

### DIFF
--- a/src/main/java/com/openhack/toyland/dto/ContributorCreateRequest.java
+++ b/src/main/java/com/openhack/toyland/dto/ContributorCreateRequest.java
@@ -5,9 +5,11 @@ import javax.validation.constraints.NotNull;
 
 import com.openhack.toyland.domain.user.User;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class ContributorCreateRequest {

--- a/src/main/java/com/openhack/toyland/dto/ToyCreateRequest.java
+++ b/src/main/java/com/openhack/toyland/dto/ToyCreateRequest.java
@@ -10,9 +10,11 @@ import com.openhack.toyland.domain.toy.Period;
 import com.openhack.toyland.domain.toy.Toy;
 import com.openhack.toyland.domain.user.User;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class ToyCreateRequest {

--- a/src/test/java/com/openhack/toyland/IntegrationTest.java
+++ b/src/test/java/com/openhack/toyland/IntegrationTest.java
@@ -1,7 +1,6 @@
 package com.openhack.toyland;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -12,7 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public abstract class IntegrationTest extends PersistenceTest {
     public static MockMvc mockMvc;
 
-    public ObjectMapper objectMapper;
+    public static ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeAll
     static void beforeAll(WebApplicationContext webApplicationContext) {
@@ -20,11 +19,5 @@ public abstract class IntegrationTest extends PersistenceTest {
             .webAppContextSetup(webApplicationContext)
             .addFilters(new CharacterEncodingFilter("UTF-8", true))
             .build();
-    }
-
-    @Override
-    @BeforeEach
-    public void setUp() {
-        objectMapper = new ObjectMapper();
     }
 }

--- a/src/test/java/com/openhack/toyland/PersistenceTest.java
+++ b/src/test/java/com/openhack/toyland/PersistenceTest.java
@@ -1,0 +1,56 @@
+package com.openhack.toyland;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@ActiveProfiles("test")
+@Sql(scripts = {"/db/init-test.sql", "/db/insert-test.sql"}, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = {"/db/truncate-test.sql"}, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(initializers = PersistenceTest.Initializer.class)
+@Testcontainers
+public abstract class PersistenceTest {
+
+    public static MariaDBContainer mariaDBContainer = new MariaDBContainer<>("mariadb:latest")
+        .withDatabaseName("toy_land_test");
+    private static Logger log = LoggerFactory.getLogger(PersistenceTest.class);
+
+    static {
+        mariaDBContainer.start();
+    }
+
+    public static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(ConfigurableApplicationContext applicationContext) {
+
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                applicationContext,
+                "spring.datasource.url=" + mariaDBContainer.getJdbcUrl(),
+                "spring.datasource.username=" + mariaDBContainer.getUsername(),
+                "spring.datasource.password=" + mariaDBContainer.getPassword()
+            );
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+        mariaDBContainer.followOutput(logConsumer);
+    }
+}

--- a/src/test/java/com/openhack/toyland/controller/ToyControllerTest.java
+++ b/src/test/java/com/openhack/toyland/controller/ToyControllerTest.java
@@ -1,0 +1,61 @@
+package com.openhack.toyland.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.openhack.toyland.IntegrationTest;
+import com.openhack.toyland.domain.Maintenance;
+import com.openhack.toyland.domain.MaintenanceRepository;
+import com.openhack.toyland.domain.toy.Toy;
+import com.openhack.toyland.domain.toy.ToyRepository;
+import com.openhack.toyland.dto.ContributorCreateRequest;
+import com.openhack.toyland.dto.ToyCreateRequest;
+
+@SpringBootTest
+class ToyControllerTest extends IntegrationTest {
+    @Autowired
+    private ToyRepository toyRepository;
+
+    @Autowired
+    private MaintenanceRepository maintenanceRepository;
+
+    @DisplayName("Toy를 생성할 때에 Maintenance도 생성되는지 확인한다")
+    @Test
+    void create() throws Exception {
+        ContributorCreateRequest contributor = new ContributorCreateRequest(123L, "toneyparky", "https://id.com");
+
+        ToyCreateRequest toyCreateRequest = new ToyCreateRequest(123L, "title", "password", "description", "readme",
+            "logoUrl", "githubLink", "serviceLink",
+            "email", 1L, "AI", 1L, "2021-01-18T16:36:27", Collections.singletonList(contributor),
+            Collections.singletonList(1L));
+
+        MvcResult mvcResult = mockMvc.perform(post("/api/toys")
+            .content(objectMapper.writeValueAsString(toyCreateRequest))
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andReturn();
+
+        String redirectedUrl = mvcResult.getResponse().getRedirectedUrl();
+        Long toyId = Long.parseLong(redirectedUrl.substring(10));
+
+        Toy toy = toyRepository.findById(toyId).get();
+        Maintenance maintenance = maintenanceRepository.findByToyId(toyId).get();
+
+        assertAll(
+            () -> assertThat(toy.getId()).isEqualTo(toyId),
+            () -> assertThat(maintenance.getId()).isNotNull(),
+            () -> assertThat(maintenance.getCreatedDate()).isNotNull()
+        );
+    }
+}

--- a/src/test/java/com/openhack/toyland/service/maintenance/ScheduleServiceTest.java
+++ b/src/test/java/com/openhack/toyland/service/maintenance/ScheduleServiceTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.openhack.toyland.IntegrationTest;
+import com.openhack.toyland.PersistenceTest;
 import com.openhack.toyland.domain.UpdatableMaintenance;
 
 @SpringBootTest
-public class ScheduleServiceTest extends IntegrationTest {
+public class ScheduleServiceTest extends PersistenceTest {
 
     @Autowired
     ScheduleService scheduleService;

--- a/src/test/java/com/openhack/toyland/service/maintenance/ScheduleServiceTest.java
+++ b/src/test/java/com/openhack/toyland/service/maintenance/ScheduleServiceTest.java
@@ -20,8 +20,8 @@ public class ScheduleServiceTest extends PersistenceTest {
     @Autowired
     MaintenanceService maintenanceService;
 
-    @Test
     @DisplayName("toy.service_link 가 빈 문자열이 아닌 maintenance 를 가져오는 테스트")
+    @Test
     public void testNotToFindToyServiceLinkIsEmpty() {
         List<UpdatableMaintenance> updatableMaintenanceList = maintenanceService.findAllNeedsHealthCheck();
         for (UpdatableMaintenance updatableMaintenance : updatableMaintenanceList) {


### PR DESCRIPTION
resolve: #46 
---

기존 IntegrationTest를 PersistanceTest로 수정한 후 레포지토리만을 테스트하는 테스트에 달아줬습니다.
그리고 PersistanceTest를 상속받는 IntegationTest를 생성하여 통합테스트를 하는 테스트에 달아줬습니다.
원래는 하나의 테스트파일에 몰려있었는데 레포지토리만을 테스트하는 테스트에서 MockMvc를 알 필요는 없지만 통합테스트에서는 TestContainer가 필요하기에 이런 구성을 시도해봤습니다. 


지금은 이슈의 원인을 찾기 위해 Toy의 생성이 성공하는 경우만 테스트했지만, 실패하는 경우나 다른 테스트를 추후에 추가해도 좋을 것 같습니다.


---
소연님과 이야기를 나눈 결과, 어플리케이션(JPA나 Controller) 상에서 문제가 아니라 기존에 DB에 들어있던 ddl 설정이 잘못된 것 같다는 결론에 도달했다. 

Maintenenance의 created_date가 당장 필요한 컬럼 값이 아니라 현상 유지를 하되 추후 DB를 초기화할 일이 있다면 created_date가 들어가는지 확인한다. 